### PR TITLE
adds installation link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,16 @@ see: http://brunch.io/docs/why-brunch
 
 ### Installation
 
-If you've already learned some Elixir and installed Node.js, then the first step to getting started with Phoenix is installation!
+If you've already learned some Elixir and installed Node.js, then
+ the first step to getting started with Phoenix is installation!
 
-The Phoenix documentation is amazing, so we recommend following [the official phoenix installation instructions!](https://hexdocs.pm/phoenix/installation.html)
+The Phoenix documentation is amazing, so we recommend following
+[the official phoenix installation instructions!](https://hexdocs.pm/phoenix/installation.html)
 
-You'll also need to install PostgreSQL, there is a tutorial of how to do so linked in the Phoenix installation guide linked above, but you can also check out our [`learn-postgresql`](https://github.com/dwyl/learn-postgresql) repo for instructions, and raise an issue if you have any trouble!
+You'll also need to install PostgreSQL, there is a tutorial of how to do so
+linked in the Phoenix installation guide linked above, but you can also check
+out our [`learn-postgresql`](https://github.com/dwyl/learn-postgresql) repo
+for instructions, and raise an issue if you have any trouble!
 
 
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,15 @@ You don't need to _know_ how to use Node to use Phoenix.
 the short answer is: Simplicity & Speed!
 see: http://brunch.io/docs/why-brunch
 
+### Installation
+
+If you've already learned some Elixir and installed Node.js, then the first step to getting started with Phoenix is installation!
+
+The Phoenix documentation is amazing, so we recommend following [the official phoenix installation instructions!](https://hexdocs.pm/phoenix/installation.html)
+
+You'll also need to install PostgreSQL, there is a tutorial of how to do so linked in the Phoenix installation guide linked above, but you can also check out our [`learn-postgresql`](https://github.com/dwyl/learn-postgresql) repo for instructions, and raise an issue if you have any trouble!
+
+
 
 
 ### "Hello World" Example (_5 Mins_)


### PR DESCRIPTION
I've added a small section on how to install phoenix, just linking to the phoenix documentation as I don't see the need to just rewrite it in our repo when the docs are so good!
I've also made a note about PostgreSQL, linking to `learn-postgresql`, since it's the standard DB for Phoenix, and the installation can be notoriously tricky. 
fixes #74